### PR TITLE
ASteambot_FindClientBySteam64

### DIFF
--- a/addons/sourcemod/scripting/webshortcuts_csgo.sp
+++ b/addons/sourcemod/scripting/webshortcuts_csgo.sp
@@ -322,30 +322,13 @@ public int ASteambot_Message(AS_MessageType MessageType, char[] msg, const int m
 {
 	if(MessageType == AS_NOT_FRIENDS)
 	{
-		int client = FindClientBySteamID(msg);
+		int client = ASteambot_FindClientBySteam64(msg);
 		if(client != -1)
 		{
 			ASteambot_SendMesssage(AS_FRIEND_INVITE, msg);
 			PrintToChat(client, " \x04%s\x01 You are not friend with me and I can't send you steam messages. I sent you a friend invite.", MODULE_NAME);
 		}
 	}
-}
-
-public int FindClientBySteamID(char[] steamID)
-{
-	char clientSteamID[30];
-	for (int i = MaxClients; i > 0; --i)
-	{
-		if (IsValidClient(i))
-		{
-			if (GetClientAuthId(i, AuthId_Steam2, clientSteamID, sizeof(clientSteamID)) && StrEqual(clientSteamID, steamID))
-            {
-                return i;
-            }
-		}
-	}
-	
-	return -1;
 }
 
 stock bool IsValidClient(int client)

--- a/addons/sourcemod/scripting/webshortcuts_csgo.sp
+++ b/addons/sourcemod/scripting/webshortcuts_csgo.sp
@@ -325,7 +325,10 @@ public int ASteambot_Message(AS_MessageType MessageType, char[] msg, const int m
 		int client = ASteambot_FindClientBySteam64(msg);
 		if(client != -1)
 		{
-			ASteambot_SendMesssage(AS_FRIEND_INVITE, msg);
+			char steamid[30];
+			GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid));
+			//Required because all ASteambot <= V9.4 doesn't support steamID64.
+			ASteambot_SendMesssage(AS_FRIEND_INVITE, steamid);
 			PrintToChat(client, " \x04%s\x01 You are not friend with me and I can't send you steam messages. I sent you a friend invite.", MODULE_NAME);
 		}
 	}

--- a/addons/sourcemod/scripting/webshortcuts_csgo.sp
+++ b/addons/sourcemod/scripting/webshortcuts_csgo.sp
@@ -327,7 +327,7 @@ public int ASteambot_Message(AS_MessageType MessageType, char[] msg, const int m
 		{
 			char steamid[30];
 			GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid));
-			//Required because all ASteambot <= V9.4 doesn't support steamID64.
+			//Required because all ASteambot < V9.4 doesn't support steamID64.
 			ASteambot_SendMesssage(AS_FRIEND_INVITE, steamid);
 			PrintToChat(client, " \x04%s\x01 You are not friend with me and I can't send you steam messages. I sent you a friend invite.", MODULE_NAME);
 		}


### PR DESCRIPTION
Edit code to use original ASteambot_FindClientBySteam64, and therefore, ensure compability for futur version of ASteambot.

At the time of the creation of this plugin, ASteambot_FindClientBySteam64 didn't existed.

EDIT:
I DID NOT tested it. I can't for now. Test before merge!

Procedur to test:
1) Remove bot from friend list
2) Try to get a shortcut from the bot.